### PR TITLE
Redirect to HTTPS without a trailing slash

### DIFF
--- a/yourls.vhost
+++ b/yourls.vhost
@@ -5,7 +5,7 @@
 
     RewriteCond %{LA-U:REQUEST_FILENAME} -d
     RewriteCond %{REQUEST_URI} !(.*)/$
-    RewriteCond %{HTTP:X-Forwarded-Proto} https 
+    RewriteCond %{HTTP:X-Forwarded-Proto} https
     RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]
 
     RewriteCond %{REQUEST_FILENAME} !-f

--- a/yourls.vhost
+++ b/yourls.vhost
@@ -2,6 +2,12 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteBase /
+
+    RewriteCond %{LA-U:REQUEST_FILENAME} -d
+    RewriteCond %{REQUEST_URI} !(.*)/$
+    RewriteCond %{HTTP:X-Forwarded-Proto} https 
+    RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^.*$ /yourls-loader.php [L]


### PR DESCRIPTION
The mod_dir redirects https://example.com/admin to http://example.com/admin/ when the apache is behind an HTTPS reverse proxy because the Location header requires the scheme and the apache didn't consider X-Forwarded-Proto.

This rewrite rule in this htaccess will add a trailing slash with the correct scheme.

Ref: https://serverfault.com/a/851918
Ref: https://stackoverflow.com/a/40447815

`%{LA-U:REQUEST_FILENAME}` will access the server via mod_dir and check if the resulted URL is a directory.