### PR TITLE
Read in config files from `YOURLS_PLUGIN_CONFIG_DIR`

### DIFF
--- a/config-docker.php
+++ b/config-docker.php
@@ -102,6 +102,16 @@ $yourls_reserved_URL = [
     'porn', 'faggot', 'sex', 'nigger', 'fuck', 'cunt', 'dick',
 ];
 
+/**
+ * include plugin configuration, if set
+ */
+$pluginconfig_dir = getenv_docker('YOURLS_PLUGIN_CONFIG_DIR', '');
+if ( $pluginconfig_dir != '' ) {
+    foreach ( glob( $pluginconfig_dir."/*.php") as $pluginconfig) {
+        include $pluginconfig;
+    }
+}
+
 /*
  ** Personal settings would go after here.
  */


### PR DESCRIPTION
to allow for automatic configuration of plug-ins, this PR introduces conditional processing of (plug-in) config files set up under a directory specified by YOURLS_PLUGIN_CONFIG_DIR.

Using the YOURLS container image in Kubernetes, automatic deployment is a top-most goal in rolling out the application. While the image does not include add-ons, it is easy to contruct an image that will include one or more images from https://raw.githubusercontent.com/YOURLS/awesome-yourls/main/README.md (i. e. https://hub.docker.com/repository/docker/jmozd/yourls-with-plugins, which already includes the change from this PR).

But without this PR, it is still required to edit config-docker.php and add required configuration variables, which doesn't look like an optimum solution: Instead, when defining a common directory for these configurations, you could either distribute according config files via the image (using the same "read from env" mechanism as config-docker.php) or add a ConfigMap to provide such configurations individually. Then all that is needed is to actually add the config values to the environment.

Kubernetes example, settable via the current Helm chart provided by the YOURLS project:

- create plug-in config processing i. e. for two plug-ins:

```
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: default
  name: yourls-plugin-config
data:
  yourls-hashid-yourls.php: |
    <?php
     /* Plugin configuration for Hashid-yourls plugin
     */
    
    /* HashID plug-in config */    
    define( 'HASHID_SALT', getenv_docker('YOURLS_HASHID_SALT', 'DefineYourSaltHere') ); // Salt used for Hashing URLs
    define( 'HASHID_MINLEN', getenv_docker('YOURLS_HASHID_MINLEN', 6) ); // minimum length of URL - default is 6

  yourls-ldap-plugin.php: |
    <?php
     /* Plugin configuration for LDAP plugin
     */
    
    /* LDAP plug-in config */    
    define( 'LDAPAUTH_HOST', getenv_docker('YOURLS_LDAPAUTH_HOST', 'localhost') ); // LDAP host name, IP or URL. You can use ldaps://host for LDAP with TLS
    define( 'LDAPAUTH_PORT', getenv_docker('YOURLS_LDAPAUTH_PORT', '389') ); // LDAP server port - often 389 or 636 for TLS (LDAPS)
    define( 'LDAPAUTH_BASE',  getenv_docker('YOURLS_LDAPAUTH_BASE', '') ); // Base DN (location of users)
    define( 'LDAPAUTH_USERNAME_FIELD', getenv_docker('YOURLS_LDAPAUTH_USERNAME_FILED', '') ); // (optional) LDAP field name in which username is stored
```
- create configuration values, defining the directory in which to mount above configs (could/should be Secret instead):
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: yourls-config
data:
  YOURLS_PLUGIN_CONFIG_DIR: '/var/www/html/user/plugins-config.d'
  YOURLS_PRIVATE: 'true'
  YOURLS_UNIQUE_URLS: 'false'
  YOURLS_COOKIEKEY: "itsMyCookieNotYours"
  YOURLS_PRIVATE_API: 'true'
  YOURLS_LDAPAUTH_HOST: 'ldap://someldapserver.company.com'
  YOURLS_LDAPAUTH_PORT: '389'
  YOURLS_LDAPAUTH_BASE: 'dc=company,dc=com'
  YOURLS_LDAPAUTH_USERNAME_FIELD: 'uid'
  YOURLS_LDAPAUTH_SEARCH_FILTER: '(&(uid=%s)(memberof=cn=yourls,ou=group,dc=company,dc=com))'
  YOURLS_HASHID_SALT: 'wontShowYouMySaltFolks'
```
- set according values.yaml for Helm chart:
```
[...]
extraEnvVarsCM: 'yourls-config'
extraVolumeMounts:
  - mountPath: /var/www/html/user/plugins-config.d
    name: yourls-plugin-config
extraVolumes:
  - name: yourls-plugin-config
    configMap:
      name: yourls-plugin-config
[...]
```
- deploy the Helm chart